### PR TITLE
Fix WeightModel id property and filtering

### DIFF
--- a/Shared/Manager/WeightViewModel.swift
+++ b/Shared/Manager/WeightViewModel.swift
@@ -35,10 +35,17 @@ import SwiftUI
     
     func filterWeights(month: Int) {
         DispatchQueue.main.async {
-            self.filterThreeMonth()
-            self.filterSixMonth()
-            self.filterOneYear()
             self.filterAllTime()
+            switch month {
+            case -3:
+                self.filterThreeMonth()
+            case -6:
+                self.filterSixMonth()
+            case -12:
+                self.filterOneYear()
+            default:
+                break
+            }
         }
     }
     
@@ -109,9 +116,9 @@ import SwiftUI
 }
 
 struct WeightModel: Comparable, Identifiable {
-    
-    var id: ObjectIdentifier {
-        return weight.id
+
+    var id: NSManagedObjectID {
+        return weight.objectID
     }
     
     static func < (lhs: WeightModel, rhs: WeightModel) -> Bool {


### PR DESCRIPTION
## Summary
- use `weight.objectID` for WeightModel's `Identifiable` conformance
- update `filterWeights` to honor the requested duration

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_686435077f6883208d788ac4113172d7