### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PR-Tracker
 [PR-Tracker](https://apps.apple.com/us/app/pr-tracker/id6443760870) is a workout personal record tracking app. The free version contains sections to track your body weight, bench, squat, deadlift.
-Purchasing premium allows you to add aditional lifts to track such as overhead press, log press, atlas stones, etc. 
+Purchasing premium allows you to add additional lifts to track such as overhead press, log press, atlas stones, etc. 
 
 The goal of this app is to allow users to track their personal records with simple charts to see their progress and get motivated to beat previous records! 
 With premium you are able to add goals to each lift to help with a visual aid to stay motivated. 


### PR DESCRIPTION
## Summary
- fix spelling of "aditional" on line 3 in the README

## Testing
- `grep -n additional README.md`


------
https://chatgpt.com/codex/tasks/task_e_68643e4e4e3c8320b9947cacb59c839b