### PR TITLE
Improve VoiceOver support

### DIFF
--- a/Shared/View/AddWeightView.swift
+++ b/Shared/View/AddWeightView.swift
@@ -44,19 +44,25 @@ struct AddWeightView: View {
                         switch(type.type) {
                         case "Body Weight":
                             Image(systemName: "scalemass")
+                                .accessibilityHidden(true)
                         case "Squat":
                             Image(systemName: "scalemass")
+                                .accessibilityHidden(true)
                         case "Bench":
                             Image(systemName: "scalemass")
+                                .accessibilityHidden(true)
                         case "Deadlift":
                             Image(systemName: "figure.strengthtraining.traditional")
+                                .accessibilityHidden(true)
                         default:
                             Image(systemName: "scalemass")
+                                .accessibilityHidden(true)
                         }
                         
                         HStack {
                             TextField("Weight", text: $weight)
                                 .keyboardType(.decimalPad)
+                                .accessibilityLabel("Weight")
                                 .frame(width: 150)
                                 .padding(10)
                                 .overlay(
@@ -66,6 +72,7 @@ struct AddWeightView: View {
                                 .tint(.green)
                             Text(isMetric ? "kg" : "lbs")
                                 .padding(.leading, 5)
+                                .accessibilityHidden(true)
                         }
                         .padding(.horizontal)
                     }
@@ -80,11 +87,13 @@ struct AddWeightView: View {
                 Spacer()
                 DatePicker("Date", selection: $date, in: ...Date.now, displayedComponents: .date)
                     .datePickerStyle(.compact)
+                    .accessibilityLabel("Date")
                 Spacer()
             }
                 
             TextField("Enter Note", text: $note)
                 .padding(.leading)
+                .accessibilityLabel("Note")
             
             Button(action: {
                 dateFormatter.dateFormat = "MM-dd-yyyy HH:mm"
@@ -118,6 +127,7 @@ struct AddWeightView: View {
                 Text("Submit")
                     .frame(width: 200)
             })
+            .accessibilityLabel("Submit weight")
             .buttonStyle(.borderedProminent)
             .tint(Color(.systemGreen))
             .buttonBorderShape(.roundedRectangle(radius: 12))

--- a/Shared/View/Components/AddGoalCard.swift
+++ b/Shared/View/Components/AddGoalCard.swift
@@ -60,18 +60,24 @@ struct AddGoalCard: View {
                     switch(type.type) {
                     case "Body Weight":
                         Image(systemName: "scalemass")
+                            .accessibilityHidden(true)
                     case "Squat":
                         Image(systemName: "scalemass")
+                            .accessibilityHidden(true)
                     case "Bench":
                         Image(systemName: "scalemass")
+                            .accessibilityHidden(true)
                     case "Deadlift":
                         Image(systemName: "figure.strengthtraining.traditional")
+                            .accessibilityHidden(true)
                     default:
                         Image(systemName: "scalemass")
+                            .accessibilityHidden(true)
                     }
                     if type.goal == 0.0 {
                         TextField("Enter Goal", value: $goal, format: .number)
                             .keyboardType(.decimalPad)
+                            .accessibilityLabel("Goal")
                             .textFieldStyle(.automatic)
                             .background(
                                 ZStack(alignment: .trailing) {
@@ -86,6 +92,7 @@ struct AddGoalCard: View {
                         if isMetric {
                             TextField("Current Goal: \(type.goal!.convertToMetric.formatted())", value: $goal, format: .number)
                                 .keyboardType(.decimalPad)
+                                .accessibilityLabel("Goal")
                                 .textFieldStyle(.automatic)
                                 .background(
                                     ZStack(alignment: .trailing) {
@@ -99,6 +106,7 @@ struct AddGoalCard: View {
                         } else {
                             TextField("Current Goal: \(type.goal!.formatted())", value: $goal, format: .number)
                                 .keyboardType(.decimalPad)
+                                .accessibilityLabel("Goal")
                                 .textFieldStyle(.automatic)
                                 .background(
                                     ZStack(alignment: .trailing) {

--- a/Shared/View/Home.swift
+++ b/Shared/View/Home.swift
@@ -189,12 +189,14 @@ struct Home: View {
                         Image(systemName: "gear")
                             .tint(.green)
                     })
+                    .accessibilityLabel("Settings")
                     Button(action: {
                         showNewWeight.toggle()
                     }, label: {
                         Image(systemName: "plus.circle")
                             .tint(.green)
                     })
+                    .accessibilityLabel("Add weight")
                 }
                 .sheet(isPresented: $showNewWeight, onDismiss: {
                     isLoading = true

--- a/Shared/View/OnboardingView.swift
+++ b/Shared/View/OnboardingView.swift
@@ -36,21 +36,25 @@ struct OnboardingView: View {
                 VStack(alignment: .leading, spacing: 40) {
                     HStack {
                         Image(systemName: "plus.circle")
+                            .accessibilityHidden(true)
                         Text("Add new records to your charts to track progress!")
                     }
                     
                     HStack {
                         Image(systemName: "gear")
+                            .accessibilityHidden(true)
                         Text("With premium, add additional workout variations to track like overhead press!")
                     }
                     
                     HStack {
                         Image(systemName: "star")
+                            .accessibilityHidden(true)
                         Text("With premium, add goals to help better track your progress!")
                     }
                     
                     HStack {
                         Image(systemName: "note.text")
+                            .accessibilityHidden(true)
                         Text("Add notes to your weights to remind yourself how you feel!")
                     }
                     
@@ -70,6 +74,7 @@ struct OnboardingView: View {
                 .tint(.green)
                 .controlSize(.large)
                 .padding()
+                .accessibilityHint("Open premium purchase options")
             }
             .sheet(isPresented: $showPremium, onDismiss: {
                 loadingData = true

--- a/Shared/View/Paywall.swift
+++ b/Shared/View/Paywall.swift
@@ -33,21 +33,25 @@ struct Paywall: View {
                     VStack(spacing: 40) {
                         HStack {
                             Image(systemName: "dumbbell")
+                                .accessibilityHidden(true)
                             Text("Unlimited entries for any workout")
                         }
                         
                         HStack {
                             Image(systemName: "plus.circle")
+                                .accessibilityHidden(true)
                             Text("Add additional workout options to track")
                         }
                         
                         HStack {
                             Image(systemName: "paintpalette")
+                                .accessibilityHidden(true)
                             Text("Customize chart colors and more")
                         }
                         
                         HStack {
                             Image(systemName: "arrow.up.heart")
+                                .accessibilityHidden(true)
                             Text("Import old data from HealthKit")
                         }
                     }

--- a/Shared/View/SettingsView.swift
+++ b/Shared/View/SettingsView.swift
@@ -167,6 +167,7 @@ struct SettingsView: View {
                     }, label: {
                         Image(systemName: "xmark")
                     })
+                    .accessibilityLabel("Close settings")
                 }
                 .sheet(isPresented: $showPremium, onDismiss: {
                     

--- a/Shared/View/WeightsList.swift
+++ b/Shared/View/WeightsList.swift
@@ -57,6 +57,9 @@ struct WeightsList: View {
                                         Text(weight.note ?? "")
                                             .font(.subheadline)
                                     }
+                                    .accessibilityElement(children: .combine)
+                                    .accessibilityLabel("Weight \(checkInt(val: weight.value) ? weight.value.intFormat : weight.value.doubleFormat) on \(weight.date?.formatted(date: .numeric, time: .omitted) ?? "")")
+                                    .accessibilityHint(weight.note ?? "")
                                 }
                             }.onDelete(perform: deleteValue)
                         }


### PR DESCRIPTION
## Summary
- hide decorative images from accessibility
- label text fields, buttons and rows for screen readers

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68643f6bd32c8320840006b67161137f