### PR TITLE
Add dark color previews

### DIFF
--- a/Shared/View/AddWeightView.swift
+++ b/Shared/View/AddWeightView.swift
@@ -165,13 +165,18 @@ struct AddWeightView: View {
 }
 
 struct AddWeightView_Previews: PreviewProvider {
-    
+
     static let userViewModel = UserManager()
-    
+
     static var previews: some View {
         let workout = WorkoutModel(workout: Workout(context: CoreDataManager.shared.viewContext))
-        AddWeightView(type: workout)
-            .environment(userViewModel)
-            
+        Group {
+            AddWeightView(type: workout)
+                .environment(userViewModel)
+
+            AddWeightView(type: workout)
+                .environment(userViewModel)
+                .preferredColorScheme(.dark)
+        }
     }
 }

--- a/Shared/View/Components/PickerComponent.swift
+++ b/Shared/View/Components/PickerComponent.swift
@@ -41,6 +41,10 @@ struct PickerComponent: View {
 
 struct PickerComponent_Previews: PreviewProvider {
     static var previews: some View {
-        PickerComponent()
+        Group {
+            PickerComponent()
+            PickerComponent()
+                .preferredColorScheme(.dark)
+        }
     }
 }

--- a/Shared/View/Components/PremiumCard.swift
+++ b/Shared/View/Components/PremiumCard.swift
@@ -50,10 +50,17 @@ struct PremiumCard: View {
 
 struct PremiumCard_Previews: PreviewProvider {
     static var previews: some View {
-        VStack {
-            PremiumCard(cardTitle: "Monthly Plan", cardDescription: "$0.99 / month", secondCardDescription: "Billed monthly")
-                
+        Group {
+            VStack {
+                PremiumCard(cardTitle: "Monthly Plan", cardDescription: "$0.99 / month", secondCardDescription: "Billed monthly")
+
+            }
+
+            VStack {
+                PremiumCard(cardTitle: "Monthly Plan", cardDescription: "$0.99 / month", secondCardDescription: "Billed monthly")
+
+            }
+            .preferredColorScheme(.dark)
         }
-        
     }
 }

--- a/Shared/View/Components/WeightCard.swift
+++ b/Shared/View/Components/WeightCard.swift
@@ -25,7 +25,11 @@ struct WeightCard: View {
 
 struct WeightCard_Previews: PreviewProvider {
     static var previews: some View {
-        WeightCard()
-            
+        Group {
+            WeightCard()
+
+            WeightCard()
+                .preferredColorScheme(.dark)
+        }
     }
 }

--- a/Shared/View/ContentView.swift
+++ b/Shared/View/ContentView.swift
@@ -40,6 +40,10 @@ struct ContentView: View {
 
 struct ContentView_Previews: PreviewProvider {
     static var previews: some View {
-        ContentView()
+        Group {
+            ContentView()
+            ContentView()
+                .preferredColorScheme(.dark)
+        }
     }
 }

--- a/Shared/View/SettingsView.swift
+++ b/Shared/View/SettingsView.swift
@@ -222,11 +222,17 @@ struct SettingsView: View {
 }
 
 struct SettingsView_Previews: PreviewProvider {
-    
+
     static let userViewModel = UserManager()
-    
+
     static var previews: some View {
-        SettingsView(isMetric: .constant(false))
-            .environment(userViewModel)
+        Group {
+            SettingsView(isMetric: .constant(false))
+                .environment(userViewModel)
+
+            SettingsView(isMetric: .constant(false))
+                .environment(userViewModel)
+                .preferredColorScheme(.dark)
+        }
     }
 }


### PR DESCRIPTION
## Summary
- update all `PreviewProvider` definitions to include a dark color preview using `preferredColorScheme(.dark)`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6864407a5ae083209d9442f79f007b5d