### PR TITLE
Fix crash when goal left blank

### DIFF
--- a/Shared/View/Components/AddGoalCard.swift
+++ b/Shared/View/Components/AddGoalCard.swift
@@ -127,7 +127,8 @@ struct AddGoalCard: View {
             
             HStack(spacing: 56) {
                 Button(action: {
-                    WorkoutVM.addGoal(workout: type, goal: goal!)
+                    guard let validGoal = goal, validGoal > 0 else { return }
+                    WorkoutVM.addGoal(workout: type, goal: validGoal)
                     refresh.toggle()
                     self.hideKeyboard()
                     self.goal = nil
@@ -140,6 +141,7 @@ struct AddGoalCard: View {
                 .buttonStyle(.borderedProminent)
                 .tint(Color(.systemGreen))
                 .buttonBorderShape(.roundedRectangle(radius: 12))
+                .disabled(goal ?? 0 <= 0)
             }.padding(.bottom).padding(.trailing).padding(.leading)
             
             if targetValue != 0.0 {


### PR DESCRIPTION
## Summary
- validate goal before submitting so it's greater than zero

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_6864603d44808320a5e18f67dd7c196e